### PR TITLE
Add sacct support and minor convenience functions

### DIFF
--- a/bin/slurm-pipeline-status.py
+++ b/bin/slurm-pipeline-status.py
@@ -37,6 +37,9 @@ parser.add_argument(
           '%s --printUnfinished -s status.json | xargs scancel' % sys.argv[0]))
 
 parser.add_argument(
+    '--printFinished', default=False, action='store_true')
+
+parser.add_argument(
     '--printFinal', default=False, action='store_true',
     help=('If specified, print a list of job ids issued by the final steps '
           'of a specification. This can be used with the --startAfter option '
@@ -51,5 +54,7 @@ if args.printFinal:
     print('\n'.join(map(str, status.finalJobs())))
 elif args.printUnfinished:
     print('\n'.join(map(str, status.unfinishedJobs(squeueArgs=args.squeueArgs))))
+elif args.printFinished:
+    print('\n'.join(map(str, status.finishedJobs())))
 else:
     print(status.toStr(args.squeueArgs))

--- a/bin/slurm-pipeline-status.py
+++ b/bin/slurm-pipeline-status.py
@@ -50,6 +50,6 @@ status = SlurmPipelineStatus(args.specification)
 if args.printFinal:
     print('\n'.join(map(str, status.finalJobs())))
 elif args.printUnfinished:
-    print('\n'.join(map(str, status.unfinishedJobs(args.squeueArgs))))
+    print('\n'.join(map(str, status.unfinishedJobs(squeueArgs=args.squeueArgs))))
 else:
     print(status.toStr(args.squeueArgs))

--- a/bin/slurm-pipeline.py
+++ b/bin/slurm-pipeline.py
@@ -70,6 +70,11 @@ parser.add_argument(
           'priority) to 10000 (lowest priority). Note that only privileged '
           'users can specify a negative adjustment.'))
 
+parser.add_argument(
+    '--outputSpecification', '-o', default=None,
+    help=('The name of the file to which the pipeline status specification, '
+          'are written in JSON format.'))
+
 args, scriptArgs = parser.parse_known_args()
 
 sp = SlurmPipeline(args.specification)
@@ -83,13 +88,18 @@ status = sp.schedule(
 
 statusAsJSON = sp.specificationToJSON(status)
 
-print(statusAsJSON)
+if not args.outputSpecification:
+    print(statusAsJSON)
+else:
+    with open(args.outputSpecification, 'w') as output_specification:
+        output_specification.write(statusAsJSON)
+        output_specification.write('\n')
 
 # If the user forgot to redirect output to a file, save it to a tempfile
 # for them and let them know where it is. We do this because without the
 # status they will have no way to examine the job with
 # slurm-pipeline-status.py
-if os.isatty(1):
+if os.isatty(1) and not args.outputSpecification:
     fd, filename = mkstemp(prefix='slurm-pipeline-status-', suffix='.json')
     print('WARNING: You did not save stdout to a file, so I have '
           'saved the specification status to %r for you.' % filename,

--- a/slurm_pipeline/error.py
+++ b/slurm_pipeline/error.py
@@ -12,3 +12,7 @@ class SpecificationError(SlurmPipelineError):
 
 class SQueueError(SlurmPipelineError):
     'A problem was found in the output of squeue'
+
+
+class SAcctError(SlurmPipelineError):
+    'A problem was found in the output of sacct'

--- a/slurm_pipeline/sacct.py
+++ b/slurm_pipeline/sacct.py
@@ -1,0 +1,106 @@
+from os import getlogin
+import subprocess
+
+from error import SAcctError
+from datetime import datetime, timedelta
+
+class SAcct(object):
+    """
+    Fetch information about job id status from sacct.
+
+    @param sacctArgs: A C{list} of C{str} arguments to pass to sacct
+        (including the 'sacct' command itself). If C{None}, the user's
+        login name will be appended to sacct -u.
+    """
+    def __init__(self, sacctArgs=None):
+        starttime = (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d")
+        args = sacctArgs or ['sacct', '-p', '-l', '-u', getlogin(), '-S', starttime]
+        try:
+            out = subprocess.check_output(args, universal_newlines=True)
+        except OSError as e:
+            raise SAcctError("Encountered OSError (%s) when running '%s'" %
+                              (e, ' '.join(args)))
+
+        columnInfo = {
+            'JobID': {
+                'attr': 'jobid',
+                'offset': None,
+            },
+            'Elapsed': {
+                'attr': 'elapsed',
+                'offset': None,
+            },
+            'State': {
+                'attr': 'state',
+                'offset': None,
+            }
+        }
+
+        jobs = {}
+
+        for count, line in enumerate(out.split('\n')):
+            fields = line.split('|')
+            if count == 0:
+                # Process header line.
+                colsFound = 0
+                for offset, title in enumerate(fields):
+                    if title in columnInfo:
+                        if columnInfo[title]['offset'] is not None:
+                            raise SAcctError(
+                                "Multiple columns with title %r found in '%s' "
+                                'output' % (title, ' '.join(args)))
+                        else:
+                            columnInfo[title]['offset'] = offset
+                            colsFound += 1
+                if colsFound != len(columnInfo):
+                    notFound = [title for title in columnInfo
+                                if columnInfo[title]['offset'] is None]
+                    raise SAcctError(
+                        "Required column%s (%s) not found in '%s' "
+                        'output' % ('' if len(notFound) == 1 else 's',
+                                    ', '.join(sorted(notFound)),
+                                    ' '.join(args)))
+            elif count == 1:
+                # header separation line
+                continue
+            elif line:
+                # ignore job steps...
+                jobId = int(fields[columnInfo['JobID']['offset']].split('.')[0])
+                if jobId in jobs:
+                    continue
+                    # FIXME...
+                    #raise SAcctError(
+                    #    "Job id %d found more than once in '%s' "
+                    #    'output' % (jobId, ' '.join(args)))
+                jobInfo = {}
+                for title in columnInfo:
+                    if title != 'JobID':
+                        jobInfo[columnInfo[title]['attr']] = fields[columnInfo[title]['offset']]
+                jobs[jobId] = jobInfo
+
+        self.jobs = jobs
+
+    def finished(self, jobId):
+        return self.jobs[jobId]['state'] not in ['PENDING', 'RUNNING']
+
+    def failed(self, jobId):
+        return self.jobs[jobId]['state'] == 'FAILED'
+
+    def completed(self, jobId):
+        return self.jobs[jobId]['state'] == 'COMPLETED'
+
+    def state(self, jobId):
+        return self.jobs[jobId]['state']
+
+    def summarize(self, jobId):
+        """
+        Summarize a job's state.
+
+        @param jobId: An C{int} job id.
+        @raise KeyError: If the job has not yet terminated.
+        @return: a C{str} describing the job's state.
+        """
+        jobInfo = self.jobs[jobId]
+        state = jobInfo['state']
+        return 'State=%s Elapsed=%s' % (
+            jobInfo['state'], jobInfo['elapsed'])

--- a/slurm_pipeline/status.py
+++ b/slurm_pipeline/status.py
@@ -52,6 +52,15 @@ class SlurmPipelineStatus(SlurmPipelineBase):
                 result.update(jobIds)
         return result
 
+    def finishedJobs(self):
+        sacct = SAcct()
+        result = set()
+        for step in self.specification['steps'].values():
+            tasks = step['tasks']
+            for taskName, jobIds in tasks.items():
+                result.update([jobid for jobid in jobIds if sacct.finished(jobid)])
+        return result
+
     def unfinishedJobs(self, squeueArgs=None):
         """
         Get the ids of unfinished jobs emitted by a specification.

--- a/slurm_pipeline/status.py
+++ b/slurm_pipeline/status.py
@@ -38,21 +38,21 @@ class SlurmPipelineStatus(SlurmPipelineBase):
 
         SlurmPipelineBase.checkSpecification(specification)
 
-    def finalJobs(self, specification):
+    def finalJobs(self):
         """
         Get the job ids emitted by the final steps of a specification.
 
         @param specification: A C{dict} containing an execution specification.
         @return: A C{set} of C{int} job ids.
         """
-        steps = specification['steps']
+        steps = self.specification['steps']
         result = set()
-        for stepName in self.finalSteps(specification):
+        for stepName in steps:
             for jobIds in steps[stepName]['tasks'].values():
                 result.update(jobIds)
         return result
 
-    def unfinishedJobs(self, specification, squeueArgs=None):
+    def unfinishedJobs(self, squeueArgs=None):
         """
         Get the ids of unfinished jobs emitted by a specification.
 
@@ -64,7 +64,7 @@ class SlurmPipelineStatus(SlurmPipelineBase):
         """
         squeue = SQueue(squeueArgs)
         result = set()
-        for stepName in specification['steps']:
+        for stepName in self.specification['steps']:
             jobIds, jobIdsFinished = self.stepJobIdSummary(stepName, squeue)
             result.update(jobIds - jobIdsFinished)
         return result


### PR DESCRIPTION
The first two commits are:
- minor refactoring of `status.py`
- option to write `output_specification` into a file
The latter two commits add:
- `SAcct`-Object which parses the output of `sacct` 
- adds printFinished functionality (using `SAcct`) and state and elapsed time information to the result

Depending on your wishes we could split this up into 3 PRs.